### PR TITLE
Create ru_ru.json & fix en_us.json a little

### DIFF
--- a/src/main/java/com/krei/cmlinkedremote/LinkedRemoteScreen.java
+++ b/src/main/java/com/krei/cmlinkedremote/LinkedRemoteScreen.java
@@ -28,16 +28,14 @@ import org.jetbrains.annotations.NotNull;
 public class LinkedRemoteScreen extends AbstractSimiContainerScreen<LinkedRemoteMenu>{
 
 	protected GuiTexture background;
-    protected Component title;
 	private List<Rect2i> extraAreas = Collections.emptyList();
 
 	private IconButton resetButton;
 	private IconButton confirmButton;
 
     public LinkedRemoteScreen(LinkedRemoteMenu container, Inventory inv, Component title) {
-        super(container, inv, title);
+        super(container, inv, Component.translatable(LinkedRemote.MODID + ".gui.linked_remote.title"));
 		this.background = new GuiTexture(LinkedRemote.MODID, "linked_remote_menu", 179, 101);
-        this.title = Component.translatable(LinkedRemote.MODID + ".gui.linked_remote.title");
     }
 
 	@Override

--- a/src/main/java/com/krei/cmlinkedremote/LinkedRemoteScreen.java
+++ b/src/main/java/com/krei/cmlinkedremote/LinkedRemoteScreen.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.NotNull;
 public class LinkedRemoteScreen extends AbstractSimiContainerScreen<LinkedRemoteMenu>{
 
 	protected GuiTexture background;
+    protected Component title;
 	private List<Rect2i> extraAreas = Collections.emptyList();
 
 	private IconButton resetButton;
@@ -36,6 +37,7 @@ public class LinkedRemoteScreen extends AbstractSimiContainerScreen<LinkedRemote
     public LinkedRemoteScreen(LinkedRemoteMenu container, Inventory inv, Component title) {
         super(container, inv, title);
 		this.background = new GuiTexture(LinkedRemote.MODID, "linked_remote_menu", 179, 101);
+        this.title = Component.translatable(LinkedRemote.MODID + ".gui.linked_remote.title");
     }
 
 	@Override

--- a/src/main/resources/assets/cmlinkedremote/lang/en_us.json
+++ b/src/main/resources/assets/cmlinkedremote/lang/en_us.json
@@ -6,5 +6,7 @@
   "item.cmlinkedremote.linked_remote.tooltip.condition2": "R-Click while Sneaking",
   "item.cmlinkedremote.linked_remote.tooltip.behaviour2": "Opens the manual _Configuration Interface_.",
   "item.cmlinkedremote.linked_remote.tooltip.condition3": "R-Click while Sneaking on Redstone Link",
-  "item.cmlinkedremote.linked_remote.tooltip.behaviour3": "Copies the _Links' Frequency_."
+  "item.cmlinkedremote.linked_remote.tooltip.behaviour3": "Copies the _Links' Frequency_.",
+
+  "cmlinkedremote.gui.linked_remote.title": "Linked Remote"
 }

--- a/src/main/resources/assets/cmlinkedremote/lang/ru_ru.json
+++ b/src/main/resources/assets/cmlinkedremote/lang/ru_ru.json
@@ -1,0 +1,12 @@
+{
+  "item.cmlinkedremote.linked_remote": "Редстоуновый пульт",
+  "item.cmlinkedremote.linked_remote.tooltip.summary": "Предоставляет _ручной контроль_ над частотой _редстоунового передатчика_, присвоенной его _единственной кнопке_.",
+  "item.cmlinkedremote.linked_remote.tooltip.condition1": "ПКМ с предметом",
+  "item.cmlinkedremote.linked_remote.tooltip.behaviour1": "_Подаёт редстоун-сигнал_ на привязанную частоту.",
+  "item.cmlinkedremote.linked_remote.tooltip.condition2": "ПКМ крадучись",
+  "item.cmlinkedremote.linked_remote.tooltip.behaviour2": "Открывает _интерфейс конфигурации_.",
+  "item.cmlinkedremote.linked_remote.tooltip.condition3": "ПКМ крадучись по передатчику сигнала",
+  "item.cmlinkedremote.linked_remote.tooltip.behaviour3": "Привязывает кнопку к _частоте передатчика_.",
+
+  "cmlinkedremote.gui.linked_remote.title": "Выбор частоты"
+}


### PR DESCRIPTION
1. `en_us.json` fixes:
 - Introduced a separate string for the GUI title: fixes potentially long translations of the item name not fitting within the narrow GUI sprite.

2. `ru_ru.json` translation:
 - Summoning @mpustovoi for a quick review.